### PR TITLE
Allow package to be installable with all dependencies + fix entry point issues

### DIFF
--- a/hop/apps/SNalert/__main__.py
+++ b/hop/apps/SNalert/__main__.py
@@ -23,7 +23,7 @@ def append_subparser(subparser, cmd, func):
     parser.set_defaults(func=func)
     return parser
 
-def _set_up_parser():
+def set_up_cli():
     """Set up parser for hop-SNalert app entry point.
 
     """
@@ -50,23 +50,15 @@ def _set_up_parser():
     return parser
 
 
-def _set_up_cli():
-    """Set up CLI boilerplate for hop-SNalert app entry point.
-
-    """
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-
-    parser = _set_up_parser()
-    return parser.parse_args()
-
-
 # ------------------------------------------------
 # -- main
 
 def main():
-    args = _set_up_cli()
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    # do stuff here
+    parser = set_up_cli()
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/hop/apps/SNalert/__main__.py
+++ b/hop/apps/SNalert/__main__.py
@@ -24,10 +24,10 @@ def append_subparser(subparser, cmd, func):
     return parser
 
 def set_up_cli():
-    """Set up parser for hop-SNalert app entry point.
+    """Set up parser for SNalert entry point.
 
     """
-    parser = argparse.ArgumentParser(prog="hop-SNalert")
+    parser = argparse.ArgumentParser(prog="SNalert")
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s version {__version__}",
     )

--- a/hop/apps/SNalert/db_storage.py
+++ b/hop/apps/SNalert/db_storage.py
@@ -1,7 +1,7 @@
 from pymongo import MongoClient
 import datetime
 from bson.objectid import ObjectId
-import IStorage
+from . import IStorage
 
 class storage(IStorage.IStorage):
     def __init__(self, timeout, datetime_format, server, drop_db):

--- a/hop/apps/SNalert/decider.py
+++ b/hop/apps/SNalert/decider.py
@@ -1,6 +1,6 @@
-import db_storage
-import IDecider
 import datetime
+from . import db_storage
+from . import IDecider
 
 class Decider(IDecider.IDecider):
     def __init__(self, time_threshold, datetime_format, mongoServer, drop_db):

--- a/hop/apps/SNalert/model.py
+++ b/hop/apps/SNalert/model.py
@@ -9,12 +9,9 @@ from hop.auth import Auth
 from hop.models import GCNCircular
 from hop import subscribe
 import sys
-import decider
-import msgSchema
 from pprint import pprint
 import subprocess
 import threading
-from dataPacket import RegularDataPacket
 import pickle
 import time
 import datetime
@@ -25,8 +22,9 @@ import dotenv
 import os
 import uuid
 
-from hypothesis import given
-from hypothesis.strategies  import lists, integers
+from . import decider
+from . import msgSchema
+from .dataPacket import RegularDataPacket
 
 
 # https://github.com/scimma/may2020-techthon-demo/blob/master/hop/apps/email/example.py
@@ -36,6 +34,22 @@ def _add_parser_args(parser):
     # All args from the subscriber
     subscribe._add_parser_args(parser)
 
+    # parser.add_argument('--t', type=int, metavar='N',
+    #                     help='The time period where observations of a supernova could occur. unit: seconds')
+    # parser.add_argument('--time-format', type=str, metavar='N',
+    #                     help='The format of the time string in all messages.')
+    # parser.add_argument('--emails-file', type=str, metavar='N',
+    #                     help='Send alerts to these emails upon possible SN.')
+    # parser.add_argument('--mongo-server', type=str, metavar='N',
+    #                     help='The MongoDB server to be used.')
+    # parser.add_argument('--drop-db', type=str, metavar='N',
+    #                     help='Whether to drop and restart a database or not.')
+
+    ## FORMAL ENVIRONMENTAL VARIABLES
+    # parser.add_argument('--username', type=str, metavar='N',
+    #                     help='The credential for Hopskotch. If not specified, look for the default file under .config/hop')
+    # parser.add_argument('--password', type=str, metavar='N',
+    #                     help='The credential for Hopskotch. If not specified, look for the default file under .config/hop')
     parser.add_argument('--f', type=str, metavar='N',
                         help="The path to the .env file.")
     parser.add_argument('--default-authentication', type=str,
@@ -262,30 +276,6 @@ def main(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     _add_parser_args(parser)
-    # parser.add_argument('--t', type=int, metavar='N',
-    #                     help='The time period where observations of a supernova could occur. unit: seconds')
-    # parser.add_argument('--time-format', type=str, metavar='N',
-    #                     help='The format of the time string in all messages.')
-    # parser.add_argument('--emails-file', type=str, metavar='N',
-    #                     help='Send alerts to these emails upon possible SN.')
-    # parser.add_argument('--mongo-server', type=str, metavar='N',
-    #                     help='The MongoDB server to be used.')
-    # parser.add_argument('--drop-db', type=str, metavar='N',
-    #                     help='Whether to drop and restart a database or not.')
-    
-    ## FORMAL ENVIRONMENTAL VARIABLES
-    # parser.add_argument('--username', type=str, metavar='N',
-    #                     help='The credential for Hopskotch. If not specified, look for the default file under .config/hop')
-    # parser.add_argument('--password', type=str, metavar='N',
-    #                     help='The credential for Hopskotch. If not specified, look for the default file under .config/hop')
-    parser.add_argument('--f', type=str, metavar='N',
-                        help="The path to the .env file.")
-    parser.add_argument('--default-authentication', type=str,
-                        help='Whether to use local ~/.config/hop-client/config.toml file or not.')
     args = parser.parse_args()
 
-    # model = Model(args)
     main(args)
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 
 # requirements
 install_requires = [
-    "hop-client >= 0.0.5",
+    "hop-client >= 0.1",
+    "jsonschema",
+    "pymongo",
+    "python-dotenv",
 ]
 extras_require = {
     'dev': ['pytest', 'pytest-console-scripts', 'pytest-cov', 'flake8', 'flake8-black'],
@@ -25,11 +28,11 @@ setup(
     author_email = 'yx48@rice.edu/skyxuyy@gmail.com',
     license = 'BSD 3-Clause',
 
-    packages = ['hop.apps.SNalert'],
+    packages = ['hop.apps.SNalert', 'hop.apps.SNalert.dataPacket'],
 
     entry_points = {
         'console_scripts': [
-            'hop-SNalert = hop.apps.SNalert.__main__:main',
+            'SNalert = hop.apps.SNalert.__main__:main',
         ],
     },
 


### PR DESCRIPTION
This PR should fix a few issues associated with having the package be installable and having the entry point register the `model` command.

First, I modified the all the imports local to this package to use relative imports (`import model` -> `from . import model`), which allows the package to be installable in the normal way. I removed this `hypothesis` package from being imported since I didn't see it used anywhere, hope that's okay.

I also added in all the dependencies used within this package in `setup.py` so they get automatically installed if you run `pip install .` in the project root.

Finally, there were a few issues with the entry point that were fixed in `__main__.py`. I also modified the entry point name so that it's a bit shorter (to `SNalert`). Now you can run something like:

```
 $ SNalert model --help
usage: SNalert model [-h] [--no-auth] [-s {EARLIEST,LATEST,PRODUCER}] [-p] [-j] [--f N] [--default-authentication DEFAULT_AUTHENTICATION] URL

main function

positional arguments:
  URL                   Sets the URL (kafka://host[:port]/topic) to publish messages to.

optional arguments:
  -h, --help            show this help message and exit
  --no-auth             If set, disable authentication.
  -s {EARLIEST,LATEST,PRODUCER}, --start-at {EARLIEST,LATEST,PRODUCER}
                        Set the message offset offset to start at. Default: LATEST.
  -p, --persist         If set, persist or listen to messages indefinitely. Otherwise, will stop listening when EOS is received.
  -j, --json            Request message output as raw json
  --f N                 The path to the .env file.
  --default-authentication DEFAULT_AUTHENTICATION
                        Whether to use local ~/.config/hop-client/config.toml file or not.
```

```
$ SNalert model --f .env kafka://localhost:9092/snews-testing --default-authentication false
<class 'str'>
--THE MODEL
...
```