### PR TITLE
Some more simplification and cleanup

### DIFF
--- a/doc/api/example.rst
+++ b/doc/api/example.rst
@@ -1,7 +1,0 @@
-.. _example:
-
-SNalert.example
-####################################
-
-.. automodule:: hop.apps.SNalert.example
-    :members:

--- a/hop/apps/SNalert/__main__.py
+++ b/hop/apps/SNalert/__main__.py
@@ -8,7 +8,6 @@ from . import model
 
 
 def append_subparser(subparser, cmd, func):
-
     assert func.__doc__, "empty docstring: {}".format(func)
     help_ = func.__doc__.split("\n")[0].lower().strip(".")
     desc = func.__doc__.strip()
@@ -23,6 +22,7 @@ def append_subparser(subparser, cmd, func):
     parser.set_defaults(func=func)
     return parser
 
+
 def set_up_cli():
     """Set up parser for SNalert entry point.
 
@@ -32,26 +32,16 @@ def set_up_cli():
         "--version", action="version", version=f"%(prog)s version {__version__}",
     )
 
-    # my arguments here
-    subparser = parser.add_subparsers(
-        title="Commands",
-        metavar="",
-        dest="cmd"
-    )
-
+    # set up parser for subcommands
+    subparser = parser.add_subparsers(title="commands", metavar="", dest="cmd")
     subparser.required = True
-
 
     # registering the app
     p = append_subparser(subparser, "model", model.main)
     model._add_parser_args(p)
 
-
     return parser
 
-
-# ------------------------------------------------
-# -- main
 
 def main():
     signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/hop/apps/SNalert/db_storage.py
+++ b/hop/apps/SNalert/db_storage.py
@@ -11,22 +11,18 @@ class storage(IStorage.IStorage):
         :param datetime_format:
         '''
         # Construct Mongodb first, used to store the json dictionary
-        # self.client = MongoClient()
-        # self.client = MongoClient('localhost', 27017)
         self.client = MongoClient(server)
 
         self.db = self.client.test_database
         self.all_messages = self.db.test_collection
         self.cache = self.db.test_cache
         # drop the database and previous records
-        if drop_db == True:
+        if drop_db:
             self.all_messages.delete_many({})
             self.cache.delete_many({})
             self.all_messages.drop_indexes()
             self.cache.drop_indexes()
         # don't drop
-        # self.all_messages.create_index("SENT TIME")
-        # self.cache.create_index("SENT TIME", expireAfterSeconds=timeout)
         self.all_messages.create_index("sent_time")
         self.cache.create_index("sent_time", expireAfterSeconds=timeout)
 
@@ -44,8 +40,6 @@ class storage(IStorage.IStorage):
         time2 = datetime.datetime.strptime(sent_time, self.datetime_format)
         time3 = datetime.datetime.strptime(neutrino_time, self.datetime_format)
         message2 = message
-        # message2["SENT TIME"] = time2
-        # message2["NEUTRINO TIME"] = time3
         message2["sent_time"] = time2
         message2["neutrino_time"] = time3
         # first insert into MongoDB
@@ -65,11 +59,9 @@ class storage(IStorage.IStorage):
         sort by 2 gives dates from recent to old
         :return:
         """
-        # return self.all_messages.find().sort("SENT TIME", -1)
         return self.all_messages.find().sort("sent_time", -1)
 
     def getCacheMsgs(self):
-        # return self.cache.find().sort("SENT TIME", -1)
         return self.cache.find().sort("sent_time", -1)
 
     def cacheEmpty(self):

--- a/hop/apps/SNalert/decider.py
+++ b/hop/apps/SNalert/decider.py
@@ -39,15 +39,12 @@ class Decider(IDecider.IDecider):
             prev = datetime.datetime.min
             prev_location = "FOO LOCATION"
             for msg in cacheMsgs:
-                # neutrinoTime = msg["NEUTRINO TIME"]
                 neutrinoTime = msg["neutrino_time"]
                 if neutrinoTime - datetime.timedelta(seconds=self.tightThreshold) <= prev:
                     # verify location
-                    # if msg["header"]["LOCATION"] != prev_location:
                     if msg["location"] != prev_location:
                         return True
                 prev = neutrinoTime
-                # prev_location = msg["header"]["LOCATION"]
                 prev_location = msg["location"]
         return False
 

--- a/hop/apps/SNalert/example.py
+++ b/hop/apps/SNalert/example.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-
-# this is just an example module, to show how
-# the sphinx api docs are registered

--- a/hop/apps/SNalert/model.py
+++ b/hop/apps/SNalert/model.py
@@ -6,6 +6,7 @@ import os
 import random
 import smtplib
 import sys
+import threading
 import time
 import uuid
 
@@ -97,28 +98,32 @@ class Model(object):
         }
 
 
-    # def writeCustomMsg(self):
-    #     while True:
-    #         stream = Stream(auth=self.auth)
-    #
-    #         obsMsg = SNEWSObservation(str(uuid.uuid4()),
-    #                                 "DETECTOR 1",
-    #                                 datetime.datetime.utcnow().strftime(os.getenv("TIME_STRING_FORMAT")),
-    #                                 datetime.datetime.utcnow().strftime(os.getenv("TIME_STRING_FORMAT")),
-    #                                 datetime.datetime.utcnow().strftime(os.getenv("TIME_STRING_FORMAT")),
-    #                                 test_locations[random.randint(0, 3)],
-    #                                 "0.5",
-    #                                 "On",
-    #                                 "For testing")
-    #
-    #         with stream.open(os.getenv("TESTING_TOPIC"), "w") as s:
-    #             s.write(obsMsg)
+    def writeCustomMsg(self):
+        test_locations = ["Houston", "Austin", "Seattle", "San Diego"]
+        while True:
+            stream = Stream(auth=self.auth)
+
+            obsMsg = SNEWSObservation(str(uuid.uuid4()),
+                                      "DETECTOR 1",
+                                      datetime.datetime.utcnow().strftime(os.getenv("TIME_STRING_FORMAT")),
+                                      datetime.datetime.utcnow().strftime(os.getenv("TIME_STRING_FORMAT")),
+                                      datetime.datetime.utcnow().strftime(os.getenv("TIME_STRING_FORMAT")),
+                                      test_locations[random.randint(0, 3)],
+                                      "0.5",
+                                      "On",
+                                      "For testing")
+
+            with stream.open(os.getenv("TESTING_TOPIC"), "w") as s:
+                s.write(obsMsg)
 
     def run(self):
         """
         Execute the model.
         :return: none
         """
+        # t = threading.Thread(target=self.writeCustomMsg)
+        # t.start()
+
         stream = Stream(persist=True, auth=self.auth)
         with stream.open(self.testing_topic, "r") as s:
             self.deciderUp = True

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
 import os
+import re
 from setuptools import setup
 
 # read in README
 this_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
     long_description = f.read().decode().strip()
+
+# load version
+with open("hop/apps/SNalert/_version.py", "r") as f:
+    version_file = f.read()
+version_match = re.search(r"^version = ['\"]([^'\"]*)['\"]", version_file, re.M)
+version = version_match.group(1)
 
 # requirements
 install_requires = [
@@ -21,6 +28,7 @@ extras_require = {
 
 setup(
     name = 'hop-SNalert-app',
+    version = version,
     description = 'An alert application for observing supernovas.',
     long_description = long_description,
     long_description_content_type = 'text/markdown',


### PR DESCRIPTION
## Description

This PR does another sweep at the codebase, removing unused modules and functions, removing outdated code and cleaning up some of the imports. I also fixed the processing of the version in `setup.py` so that the version is recognized properly upon installation. Also, moved the `model.run()` call from instantiation to be expected to be called afterwards to have better control of when the model starts running.

In addition, there have been changes related to the CLI:

* `--f` -> `--env-file` or `-f` for short. This should provide a more descriptive name when parsing.
* change `--default-authentication` to be renamed to `--use-default-auth` which is a flag that gets set to True when passed in. This should simplify the handling of booleans since it's already a boolean after being parsed.
* Make use of `--no-auth` option to disable authentication, which provides a mechanism to do local development.
* Swap out adding in options from `subscribe` to ones provided by `hop.cli`. `hop.subscribe._add_parser_args` is an internal function that should be used outside of hop.
* Change the `NEW_VARIABLE` arg in the .env file to be 0 or 1, which can be converted to a boolean easily without the extra work to process different types of strings.