### PR TITLE
Hop client improvements + add fake message generation via `SNalert generate`

### DIFF
--- a/hop/apps/SNalert/__main__.py
+++ b/hop/apps/SNalert/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import signal
 
 from . import __version__
+from . import generate
 from . import model
 
 
@@ -36,7 +37,10 @@ def set_up_cli():
     subparser = parser.add_subparsers(title="commands", metavar="", dest="cmd")
     subparser.required = True
 
-    # registering the app
+    # register commands
+    p = append_subparser(subparser, "generate", generate.main)
+    generate._add_parser_args(p)
+
     p = append_subparser(subparser, "model", model.main)
     model._add_parser_args(p)
 
@@ -44,8 +48,6 @@ def set_up_cli():
 
 
 def main():
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-
     parser = set_up_cli()
     args = parser.parse_args()
     args.func(args)

--- a/hop/apps/SNalert/generate.py
+++ b/hop/apps/SNalert/generate.py
@@ -1,0 +1,77 @@
+import argparse
+import datetime
+import os
+import random
+import time
+import uuid
+
+from dotenv import load_dotenv
+
+from hop import Stream
+
+from .dataPacket.observationMsg import SNEWSObservation
+from .dataPacket.heartbeatMsg import SNEWSHeartbeat
+
+
+def generate_message(time_string_format, alert_probability=0.1):
+    """Generate fake SNEWS alerts/heartbeats.
+    """
+    test_locations = ["Houston", "Austin", "Seattle", "San Diego"]
+    test_detectors = ["DETECTOR 1", "DETECTOR 2"]
+    if random.random() > alert_probability:
+        return SNEWSHeartbeat(
+            message_id=str(uuid.uuid4()),
+            detector_id=test_detectors[random.randint(0, 1)],
+            sent_time=datetime.datetime.utcnow().strftime(time_string_format),
+            machine_time=datetime.datetime.utcnow().strftime(time_string_format),
+            location=test_locations[random.randint(0, 3)],
+            status="On",
+            content="For testing",
+        )
+    else:
+        return SNEWSObservation(
+            message_id=str(uuid.uuid4()),
+            detector_id=test_detectors[random.randint(0, 1)],
+            sent_time=datetime.datetime.utcnow().strftime(time_string_format),
+            neutrino_time=datetime.datetime.utcnow().strftime(time_string_format),
+            machine_time=datetime.datetime.utcnow().strftime(time_string_format),
+            location=test_locations[random.randint(0, 3)],
+            p_value=0.5,
+            status="On",
+            content="For testing",
+        )
+
+
+def _add_parser_args(parser):
+    """Parse arguments for broker, configurations and options
+    """
+    parser.add_argument('-f', '--env-file', type=str, help="The path to the .env file.")
+    parser.add_argument('--rate', type=float, default=0.5,
+                        help="Rate to send alerts, default=0.5s")
+    parser.add_argument('--alert-probability', type=float, default=0.1,
+                        help="Probability of generating an alert. Default = 0.1.")
+
+
+def main(args):
+    """main function
+    """
+    # load environment variables
+    load_dotenv(dotenv_path=args.env_file)
+
+    # configure and open observation stream
+    stream = Stream(auth=False)
+    source = stream.open(os.getenv("OBSERVATION_TOPIC"), "w")
+
+    # generate messages
+    try:
+        while True:
+            message = generate_message(
+                os.getenv("TIME_STRING_FORMAT"),
+                alert_probability=args.alert_probability,
+            )
+            source.write(message)
+            time.sleep(args.rate)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        source.close()


### PR DESCRIPTION
## Description

This PR adds some improvements in how hop-client is used for fault tolerance and reuse of open stream connections. It also moves some of the fake data generate to its own command, `SNalert generate`. Also removed the testing/heartbeat topics in the config in favor of just the alert and observatory topics. In addition, I removed this signal handler in `__main__.py` since it doesn't play nicely with keyboard interrupts. Finally, removed the URL option in the CLI since it's unused and loaded in from the configuration.

Local configuration looks like:

```
TIMEOUT=120
TIME_STRING_FORMAT="%y/%m/%d %H:%M:%S"
DATABASE_SERVER="mongodb://localhost:27017/"
NEW_DATABASE=1

USERNAME="user"
PASSWORD="pass"

HOP_BROKER="localhost:9092"
OBSERVATION_TOPIC="kafka://${HOP_BROKER}/snews-experiments"
ALERT_TOPIC="kafka://${HOP_BROKER}/snews-alert"
```

Example commands:
`SNalert model -f dev-config.env --no-auth`
`SNalert generate -f dev-config.env` 
