### PR TITLE
add logging to model and generate commands

### DIFF
--- a/hop/apps/SNalert/generate.py
+++ b/hop/apps/SNalert/generate.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import logging
 import os
 import random
 import time
@@ -13,29 +14,36 @@ from .dataPacket.observationMsg import SNEWSObservation
 from .dataPacket.heartbeatMsg import SNEWSHeartbeat
 
 
+logger = logging.getLogger("snews")
+
+
 def generate_message(time_string_format, alert_probability=0.1):
     """Generate fake SNEWS alerts/heartbeats.
     """
     test_locations = ["Houston", "Austin", "Seattle", "San Diego"]
     test_detectors = ["DETECTOR 1", "DETECTOR 2"]
+    location = test_locations[random.randint(0, 3)]
+    detector_id = test_detectors[random.randint(0, 1)]
     if random.random() > alert_probability:
+        logging.debug(f"generating heartbeat from {location} at {detector_id}")
         return SNEWSHeartbeat(
             message_id=str(uuid.uuid4()),
-            detector_id=test_detectors[random.randint(0, 1)],
+            detector_id=detector_id,
             sent_time=datetime.datetime.utcnow().strftime(time_string_format),
             machine_time=datetime.datetime.utcnow().strftime(time_string_format),
-            location=test_locations[random.randint(0, 3)],
+            location=location,
             status="On",
             content="For testing",
         )
     else:
+        logging.debug(f"generating alert from {location} at {detector_id}")
         return SNEWSObservation(
             message_id=str(uuid.uuid4()),
-            detector_id=test_detectors[random.randint(0, 1)],
+            detector_id=detector_id,
             sent_time=datetime.datetime.utcnow().strftime(time_string_format),
             neutrino_time=datetime.datetime.utcnow().strftime(time_string_format),
             machine_time=datetime.datetime.utcnow().strftime(time_string_format),
-            location=test_locations[random.randint(0, 3)],
+            location=location,
             p_value=0.5,
             status="On",
             content="For testing",
@@ -45,6 +53,7 @@ def generate_message(time_string_format, alert_probability=0.1):
 def _add_parser_args(parser):
     """Parse arguments for broker, configurations and options
     """
+    parser.add_argument('-v', '--verbose', action='count', default=0, help="Be verbose.")
     parser.add_argument('-f', '--env-file', type=str, help="The path to the .env file.")
     parser.add_argument('--rate', type=float, default=0.5,
                         help="Rate to send alerts, default=0.5s")
@@ -55,14 +64,23 @@ def _add_parser_args(parser):
 def main(args):
     """main function
     """
+    # set up logging
+    verbosity = [logging.WARNING, logging.INFO, logging.DEBUG]
+    logging.basicConfig(
+        level=verbosity[min(args.verbose, 2)],
+        format="%(asctime)s | model : %(levelname)s : %(message)s",
+    )
+
     # load environment variables
     load_dotenv(dotenv_path=args.env_file)
 
     # configure and open observation stream
+    logger.info(f"starting up stream")
     stream = Stream(auth=False)
     source = stream.open(os.getenv("OBSERVATION_TOPIC"), "w")
 
     # generate messages
+    logger.info(f"publishing messages to {os.getenv('OBSERVATION_TOPIC')}")
     try:
         while True:
             message = generate_message(
@@ -74,4 +92,5 @@ def main(args):
     except KeyboardInterrupt:
         pass
     finally:
+        logger.info("shutting down")
         source.close()

--- a/hop/apps/SNalert/model.py
+++ b/hop/apps/SNalert/model.py
@@ -2,6 +2,7 @@
 
 import argparse
 import datetime
+import logging
 import os
 import sys
 import time
@@ -23,14 +24,13 @@ from .dataPacket.heartbeatMsg import SNEWSHeartbeat
 from .dataPacket.alertMsg import SNEWSAlert
 
 
+logger = logging.getLogger("snews")
+
+
 def _add_parser_args(parser):
     """Parse arguments for broker, configurations and options
     """
-    ## FORMAL ENVIRONMENTAL VARIABLES
-    # parser.add_argument('--username', type=str, metavar='N',
-    #                     help='The credential for Hopskotch. If not specified, look for the default file under .config/hop')
-    # parser.add_argument('--password', type=str, metavar='N',
-    #                     help='The credential for Hopskotch. If not specified, look for the default file under .config/hop')
+    parser.add_argument('-v', '--verbose', action='count', default=0, help="Be verbose.")
     parser.add_argument('-f', '--env-file', type=str, help="The path to the .env file.")
     parser.add_argument('--use-default-auth', action="store_true",
                         help='If set, use local ~/.config/hop-client/config.toml file to authenticate.')
@@ -63,10 +63,20 @@ class Model(object):
 
         self.args = args
         self.gcnFormat = "json"
+        self.db_server = os.getenv("DATABASE_SERVER")
         self.drop_db = bool(os.getenv("NEW_DATABASE"))
-        self.myDecider = decider.Decider(int(os.getenv("TIMEOUT")), os.getenv("TIME_STRING_FORMAT"), os.getenv("DATABASE_SERVER"), self.drop_db)
-        self.deciderUp = False
         self.regularMsgSchema = msgSchema.regularMsgSchema
+
+        logger.info(f"setting up decider at: {self.db_server}")
+        self.myDecider = decider.Decider(
+            int(os.getenv("TIMEOUT")),
+            os.getenv("TIME_STRING_FORMAT"),
+            self.db_server,
+            self.drop_db
+        )
+        if self.drop_db:
+            logger.info("clearing out decider cache")
+        self.deciderUp = False
 
         # configure authentication
         if args.no_auth:
@@ -99,6 +109,8 @@ class Model(object):
         :return: none
         """
         self.deciderUp = True
+        logger.info(f"starting decider")
+        logger.info(f"processing messages from {self.observation_topic}")
         for msg, meta in self.source.read(metadata=True, autocommit=False):
             self.processMessage(msg)
             self.source.mark_done(meta)
@@ -107,6 +119,7 @@ class Model(object):
         """
         Close stream connections.
         """
+        logger.info(f"shutting down")
         self.deciderUp = False
         self.source.close()
         self.sink.close()
@@ -116,6 +129,7 @@ class Model(object):
 
     def processMessage(self, message):
         message_type = type(message).__name__
+        logger.debug(f"processing {message_type}")
         if message_type in self.mapping:
             self.mapping[message_type](message)
 
@@ -124,6 +138,7 @@ class Model(object):
         alert = self.myDecider.deciding()
         if alert:
             # publish to TOPIC2 and alert astronomers
+            logger.info("found coincidence, sending alert")
             self.sink.write(self.writeAlertMsg())
 
     def processHeartbeatMessage(self, message):
@@ -141,6 +156,14 @@ class Model(object):
 def main(args):
     """main function
     """
+    # set up logging
+    verbosity = [logging.WARNING, logging.INFO, logging.DEBUG]
+    logging.basicConfig(
+        level=verbosity[min(args.verbose, 2)],
+        format="%(asctime)s | model : %(levelname)s : %(message)s",
+    )
+
+    # start up
     model = Model(args)
     try:
         model.run()


### PR DESCRIPTION
## Description

This PR adds some basic logging to `SNalert generate` and `SNalert model` that can be turned on by specifying the `--verbose` or `-v` flags. This can be passed up to two times to add detailed logging (debug mode) and by default does not show any logging messages.