### PR TITLE
Clean up authentication handling within app

### DIFF
--- a/snews/generate.py
+++ b/snews/generate.py
@@ -53,6 +53,7 @@ def _add_parser_args(parser):
     """
     parser.add_argument('-v', '--verbose', action='count', default=0, help="Be verbose.")
     parser.add_argument('-f', '--env-file', type=str, help="The path to the .env file.")
+    parser.add_argument("--no-auth", action="store_true", help="If set, disable authentication.")
     parser.add_argument('--rate', type=float, default=0.5,
                         help="Rate to send alerts, default=0.5s")
     parser.add_argument('--alert-probability', type=float, default=0.1,
@@ -78,7 +79,7 @@ def main(args):
 
     # configure and open observation stream
     logger.info(f"starting up stream")
-    stream = Stream(auth=False)
+    stream = Stream(auth=(not args.no_auth))
     source = stream.open(os.getenv("OBSERVATION_TOPIC"), "w")
 
     # generate messages

--- a/snews/model.py
+++ b/snews/model.py
@@ -30,8 +30,6 @@ def _add_parser_args(parser):
     """
     parser.add_argument('-v', '--verbose', action='count', default=0, help="Be verbose.")
     parser.add_argument('-f', '--env-file', type=str, help="The path to the .env file.")
-    parser.add_argument('--use-default-auth', action="store_true",
-                        help='If set, use local ~/.config/hop-client/config.toml file to authenticate.')
     parser.add_argument("--no-auth", action="store_true", help="If set, disable authentication.")
 
 
@@ -78,22 +76,12 @@ class Model(object):
             logger.info("clearing out decider cache")
         self.deciderUp = False
 
-        # configure authentication
-        if args.no_auth:
-            self.auth = False
-        elif not args.use_default_auth:
-            username = os.getenv("USERNAME")
-            password = os.getenv("PASSWORD")
-            self.auth = Auth(username, password, method=auth.SASLMethod.PLAIN)
-        else:
-            self.auth = True
-
         # specify topics
         self.observation_topic = os.getenv("OBSERVATION_TOPIC")
         self.alert_topic = os.getenv("ALERT_TOPIC")
 
         # open up stream connections
-        self.stream = Stream(auth=self.auth, persist=True)
+        self.stream = Stream(auth=(not args.no_auth), persist=True)
         self.source = self.stream.open(self.observation_topic, "r")
         self.sink = self.stream.open(self.alert_topic, "w")
 


### PR DESCRIPTION

## Description

This PR changes how authentication to Hopskotch is handled, using the hop auth configuration file to provide credentials. To turn off authentication, the `--no-auth` command line option can be passed to both `snews generate` and `snews model`.