### PR TITLE
Add command to measure latency from SNEWS messages

### DIFF
--- a/snews/__main__.py
+++ b/snews/__main__.py
@@ -4,6 +4,7 @@ import argparse
 
 from . import __version__
 from . import generate
+from . import latency
 from . import model
 
 
@@ -39,6 +40,9 @@ def set_up_cli():
     # register commands
     p = append_subparser(subparser, "generate", generate.main)
     generate._add_parser_args(p)
+
+    p = append_subparser(subparser, "latency", latency.main)
+    latency._add_parser_args(p)
 
     p = append_subparser(subparser, "model", model.main)
     model._add_parser_args(p)

--- a/snews/latency.py
+++ b/snews/latency.py
@@ -53,7 +53,7 @@ def main(args):
     # generate messages
     logger.info(f"listening to messages from {topics[args.measurement]}")
     try:
-        for message, metadata in source.read(metadata=True):
+        for message, metadata in source.read(batch_size=1, metadata=True):
             # calculate current latency
             message_timestamp = metadata.timestamp
             current_timestamp = int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds() * 1000)

--- a/snews/latency.py
+++ b/snews/latency.py
@@ -1,0 +1,71 @@
+from collections import deque
+from datetime import datetime
+import logging
+import os
+import time
+
+from dotenv import load_dotenv
+import numpy
+
+from hop import Stream
+
+
+logger = logging.getLogger("snews")
+
+
+def _add_parser_args(parser):
+    """Parse arguments for broker, configurations and options
+    """
+    parser.add_argument('-v', '--verbose', action='count', default=0, help="Be verbose.")
+    parser.add_argument('-f', '--env-file', type=str, help="The path to the .env file.")
+    parser.add_argument("--no-auth", action="store_true", help="If set, disable authentication.")
+    parser.add_argument("-m", "--measurement", choices=("alert", "observation"), default="observation",
+                        help="Specify the type of measurement to measure latency. Default = observation.")
+
+
+def main(args):
+    """Measure latency from SNEWS events.
+    """
+    # set up logging
+    verbosity = [logging.WARNING, logging.INFO, logging.DEBUG]
+    logging.basicConfig(
+        level=verbosity[min(args.verbose, 2)],
+        format="%(asctime)s | latency : %(levelname)s : %(message)s",
+    )
+
+    # load environment variables
+    load_dotenv(dotenv_path=args.env_file)
+
+    # map choices to measurements
+    topics = {
+        "alert": os.getenv("ALERT_TOPIC"),
+        "observation": os.getenv("OBSERVATION_TOPIC"),
+    }
+
+    # configure and open stream
+    logger.info("starting up")
+    stream = Stream(auth=(not args.no_auth), persist=True)
+    source = stream.open(topics[args.measurement], "r")
+
+    # track latency measurements
+    latencies = deque(maxlen = 100)
+
+    # generate messages
+    logger.info(f"listening to messages from {topics[args.measurement]}")
+    try:
+        for message, metadata in source.read(metadata=True):
+            # calculate current latency
+            message_timestamp = metadata.timestamp
+            current_timestamp = int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds() * 1000)
+            latency = (current_timestamp - message_timestamp) / 1000
+
+            # calculate mean latency
+            latencies.append(latency)
+            mean_latency = numpy.around(numpy.mean(list(latencies)), 3)
+
+            logger.info(f"current latency: {latency}s, mean latency: {mean_latency}s")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        logger.info("shutting down")
+        source.close()

--- a/snews/latency.py
+++ b/snews/latency.py
@@ -19,6 +19,8 @@ def _add_parser_args(parser):
     parser.add_argument('-v', '--verbose', action='count', default=0, help="Be verbose.")
     parser.add_argument('-f', '--env-file', type=str, help="The path to the .env file.")
     parser.add_argument("--no-auth", action="store_true", help="If set, disable authentication.")
+    parser.add_argument("-n", "--num-points", type=int, default=100,
+                        help="Number of points to compute mean. default=100")
     parser.add_argument("-m", "--measurement", choices=("alert", "observation"), default="observation",
                         help="Specify the type of measurement to measure latency. Default = observation.")
 
@@ -48,7 +50,7 @@ def main(args):
     source = stream.open(topics[args.measurement], "r")
 
     # track latency measurements
-    latencies = deque(maxlen = 100)
+    latencies = deque(maxlen=args.num_points)
 
     # generate messages
     logger.info(f"listening to messages from {topics[args.measurement]}")

--- a/snews/model.py
+++ b/snews/model.py
@@ -93,7 +93,7 @@ class Model(object):
         self.deciderUp = True
         logger.info("starting decider")
         logger.info(f"processing messages from {self.observation_topic}")
-        for msg, meta in self.source.read(metadata=True, autocommit=False):
+        for msg, meta in self.source.read(batch_size=1, metadata=True, autocommit=False):
             self.processMessage(msg)
             self.source.mark_done(meta)
 


### PR DESCRIPTION
## Description

This PR adds a new command, `snews latency`, to measure the latency produced by the various Kafka topics. Example:

```
snews latency --env-file dev-config.env -v --measurement observation
```

This will listen to a topic and compute the current latency as well as a running average over N points (configurable).

One side effect from this was that I found by tuning the `batch_size` of the `stream.read` to 1, we can lower the latency considerably from previously.