### PR TITLE
generate.py: allow generating messages from one detector with --detector

### DIFF
--- a/snews/generate.py
+++ b/snews/generate.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import datetime
 import logging
 import os
@@ -14,33 +15,33 @@ from hop.plugins.snews import SNEWSHeartbeat, SNEWSObservation
 logger = logging.getLogger("snews")
 
 
-def generate_message(time_string_format, alert_probability=0.1):
+Detector = namedtuple("Detector", "detector_id location")
+
+
+def generate_message(time_string_format, detectors, alert_probability=0.1):
     """Generate fake SNEWS alerts/heartbeats.
     """
-    test_locations = ["Houston", "Austin", "Seattle", "San Diego"]
-    test_detectors = ["DETECTOR 1", "DETECTOR 2"]
-    location = test_locations[random.randint(0, 3)]
-    detector_id = test_detectors[random.randint(0, 1)]
+    detector = detectors[random.randint(0, len(detectors) - 1)]
     if random.random() > alert_probability:
-        logging.debug(f"generating heartbeat from {location} at {detector_id}")
+        logging.debug(f"generating heartbeat from {detector.location} at {detector.detector_id}")
         return SNEWSHeartbeat(
             message_id=str(uuid.uuid4()),
-            detector_id=detector_id,
+            detector_id=detector.detector_id,
             sent_time=datetime.datetime.utcnow().strftime(time_string_format),
             machine_time=datetime.datetime.utcnow().strftime(time_string_format),
-            location=location,
+            location=detector.location,
             status="On",
             content="For testing",
         )
     else:
-        logging.debug(f"generating alert from {location} at {detector_id}")
+        logging.debug(f"generating alert from {detector.location} at {detector.detector_id}")
         return SNEWSObservation(
             message_id=str(uuid.uuid4()),
-            detector_id=detector_id,
+            detector_id=detector.detector_id,
             sent_time=datetime.datetime.utcnow().strftime(time_string_format),
             neutrino_time=datetime.datetime.utcnow().strftime(time_string_format),
             machine_time=datetime.datetime.utcnow().strftime(time_string_format),
-            location=location,
+            location=detector.location,
             p_value=0.5,
             status="On",
             content="For testing",
@@ -53,6 +54,9 @@ def _add_parser_args(parser):
     parser.add_argument('-v', '--verbose', action='count', default=0, help="Be verbose.")
     parser.add_argument('-f', '--env-file', type=str, help="The path to the .env file.")
     parser.add_argument("--no-auth", action="store_true", help="If set, disable authentication.")
+    parser.add_argument('-d', '--detector', type=str,
+                        help=("Set a specific detector:location pair to simulate messages from. "
+                              "If not set, generates messages from multiple random locations."))
     parser.add_argument('--rate', type=float, default=0.5,
                         help="Rate to send alerts, default=0.5s")
     parser.add_argument('--alert-probability', type=float, default=0.1,
@@ -64,7 +68,7 @@ def _add_parser_args(parser):
 
 
 def main(args):
-    """main function
+    """generate synthetic observation/heartbeat messages
     """
     # set up logging
     verbosity = [logging.WARNING, logging.INFO, logging.DEBUG]
@@ -75,6 +79,16 @@ def main(args):
 
     # load environment variables
     load_dotenv(dotenv_path=args.env_file)
+
+    # choose set of detector/location pairs
+    if args.detector:
+        detectors = [Detector(*args.detector.split(":"))]
+    else:
+        detectors = [
+            Detector("DETECTOR 1", "Houston"),
+            Detector("DETECTOR 2", "Seattle"),
+            Detector("DETECTOR 3", "Los Angeles"),
+        ]
 
     # configure and open observation stream
     logger.info("starting up stream")
@@ -87,6 +101,7 @@ def main(args):
         # send one message, then persist if specified
         message = generate_message(
             os.getenv("TIME_STRING_FORMAT"),
+            detectors,
             alert_probability=args.alert_probability,
         )
         source.write(message)
@@ -95,6 +110,7 @@ def main(args):
         while args.persist:
             message = generate_message(
                 os.getenv("TIME_STRING_FORMAT"),
+                detectors,
                 alert_probability=args.alert_probability,
             )
             source.write(message)


### PR DESCRIPTION
## Description

This PR reworks some of the synthetic message generation in `snews generate` to allow sending alerts from a single detector. This can be done by specifying the `--detector` option, e.g. `snews generate --detector "my_detector:my_location"`.

To make this easier, I defined a `Detector` namedtuple and used this to sample from in the case that no detector is specified (samples from 3 by default). The detectors are passed into `generate_message()` which has its function signature changed.
